### PR TITLE
Implement start simulation function

### DIFF
--- a/src/simulation.c
+++ b/src/simulation.c
@@ -1,0 +1,40 @@
+#include "philo.h"
+
+static void join_philo_threads(t_simulation *simulation, int num_philos)
+{
+    int i;
+
+    i = 0;
+    while (i < num_philos)
+    {
+        pthread_join(simulation->philosophers[i].thread, NULL);
+        i++;
+    }
+}
+
+static void create_philo_threads(t_simulation *simulation)
+{
+    int i;
+
+    i = 0;
+    while (i < simulation->number_of_philosophers)
+    {
+        if (pthread_create(&simulation->philosophers[i].thread, NULL, &philo_routine, &simulation->philosophers[i]) != 0)
+        {
+            simulation->simulation_end = true;
+            break;
+        }
+        i++;
+    }
+}
+
+bool start_simulation(t_simulation *simulation)
+{
+    if (simulation == NULL || simulation->philosophers == NULL)
+        return (false);
+    create_philo_threads(simulation);
+    if (simulation->simulation_end)
+        return (false);
+    join_philo_threads(simulation, simulation->number_of_philosophers);
+    return (true);
+}


### PR DESCRIPTION
Implements the `start_simulation` function to initiate philosopher threads and manage their lifecycle.

- **Thread Creation**: Introduces `create_philo_threads` to iterate over each philosopher and create a thread using `pthread_create`, assigning `philo_routine` as the thread function. This process is halted if thread creation fails, marking `simulation_end` as true.
- **Thread Joining**: Adds `join_philo_threads` to wait for all philosopher threads to complete using `pthread_join`, ensuring all threads are properly closed before the simulation ends.
- **Simulation Control**: Enhances the `start_simulation` function to check for null pointers in the simulation structure and philosophers array, initiate thread creation, and handle thread joining. Returns a boolean indicating the success or failure of the simulation start process.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/imaskillissue/philo?shareId=95de6d95-efb6-45bd-9eb5-5bd7555b6caa).